### PR TITLE
Fix N+1 query in AnomalyDetectionService for cold start

### DIFF
--- a/api/app/services/anomaly_detection_service.rb
+++ b/api/app/services/anomaly_detection_service.rb
@@ -4,6 +4,9 @@ class AnomalyDetectionService
   PACKET_LOSS_WARNING = 10          # > 10% loss = warning
   PACKET_LOSS_CRITICAL = 50         # > 50% loss = critical
 
+  # Sentinel to distinguish "not provided" from "nil"
+  NOT_PROVIDED = Object.new.freeze
+
   class << self
     def detect_for_batch(measurements)
       return if measurements.empty?
@@ -14,13 +17,15 @@ class AnomalyDetectionService
 
       measurements.each do |measurement|
         baseline = baselines_by_host[measurement.host]
-        detect_for_measurement(measurement, baseline)
+        detect_for_measurement(measurement, baseline: baseline)
       end
     end
 
-    def detect_for_measurement(measurement, baseline = nil)
-      # Look up baseline if not provided (for direct calls)
-      baseline ||= measurement.site.baselines.find_by(host: measurement.host)
+    def detect_for_measurement(measurement, baseline: NOT_PROVIDED)
+      # Only look up baseline if not explicitly provided (for direct calls)
+      if baseline == NOT_PROVIDED
+        baseline = measurement.site.baselines.find_by(host: measurement.host)
+      end
 
       # Cold start: skip detection if no baseline exists yet
       return if baseline.nil?

--- a/api/spec/services/anomaly_detection_service_spec.rb
+++ b/api/spec/services/anomaly_detection_service_spec.rb
@@ -307,6 +307,50 @@ RSpec.describe AnomalyDetectionService do
     end
   end
 
+  describe ".detect_for_measurement with explicit baseline parameter" do
+    let(:measurement) do
+      create(:measurement,
+        site: site,
+        host: "unknown-host",
+        ip: "192.168.1.99",
+        is_up: true,
+        latency_ms: 10.0
+      )
+    end
+
+    it "does not query for baseline when baseline: nil is explicitly passed" do
+      baseline_queries = []
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        if payload[:sql].include?("baselines") && payload[:sql].include?("SELECT")
+          baseline_queries << payload[:sql]
+        end
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        described_class.detect_for_measurement(measurement, baseline: nil)
+      end
+
+      expect(baseline_queries).to be_empty,
+        "Expected no baseline queries when baseline: nil is explicit, got: #{baseline_queries.inspect}"
+    end
+
+    it "queries for baseline when baseline parameter is not provided" do
+      baseline_queries = []
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        if payload[:sql].include?("baselines") && payload[:sql].include?("SELECT")
+          baseline_queries << payload[:sql]
+        end
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        described_class.detect_for_measurement(measurement)
+      end
+
+      expect(baseline_queries.size).to eq(1),
+        "Expected 1 baseline query when parameter not provided, got: #{baseline_queries.size}"
+    end
+  end
+
   describe "context snapshot" do
     let!(:baseline_record) { baseline }
 


### PR DESCRIPTION
## Summary
- Use sentinel value to distinguish "baseline not provided" from "baseline is nil"
- Prevents redundant queries during cold start when hosts have no baseline yet
- Added tests verifying query behavior with explicit vs omitted baseline parameter

## Problem
During cold start (no baselines calculated yet), every measurement triggered a baseline lookup query even though we already knew from the batch preload that no baseline exists.

## Test plan
- [x] New tests verify no query when `baseline: nil` is explicit
- [x] New tests verify query happens when parameter is omitted
- [x] All 16 anomaly detection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)