### PR TITLE
Make Rails API URL configurable via env var

### DIFF
--- a/noc_claude/.env.example
+++ b/noc_claude/.env.example
@@ -3,6 +3,9 @@
 # Anthropic API key for Claude
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
 
+# Rails API URL
+RAILS_API_URL=https://api.ping-monitor-home.taylorcrib.com
+
 # Rails API Agent Credentials
 # Create an agent in Rails with: Agent.create!(name: "noc-claude", secret: "your-secret")
 NC_AGENT_NAME=noc-claude

--- a/noc_claude/config.yml
+++ b/noc_claude/config.yml
@@ -2,7 +2,7 @@
 
 # Rails API connection (JWT authentication)
 rails_api:
-  url: "http://ping-monitor-api:3000"  # Or your actual API URL
+  url: "${RAILS_API_URL}"              # e.g., https://api.ping-monitor-home.taylorcrib.com
   agent_name: "${NC_AGENT_NAME}"       # Agent name registered in Rails
   agent_secret: "${NC_AGENT_SECRET}"   # Agent secret for authentication
   timeout_seconds: 30

--- a/noc_claude/docker-compose.yml
+++ b/noc_claude/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - RAILS_API_URL=${RAILS_API_URL}
       - NC_AGENT_NAME=${NC_AGENT_NAME}
       - NC_AGENT_SECRET=${NC_AGENT_SECRET}
       - TZ=America/New_York
@@ -42,6 +43,7 @@ services:
     
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - RAILS_API_URL=${RAILS_API_URL}
       - NC_AGENT_NAME=${NC_AGENT_NAME}
       - NC_AGENT_SECRET=${NC_AGENT_SECRET}
 


### PR DESCRIPTION
## Summary

Makes the Rails API URL configurable via environment variable for deployment flexibility.

### Changes

- `config.yml`: Use `${RAILS_API_URL}` instead of hardcoded URL
- `docker-compose.yml`: Add `RAILS_API_URL` to both nc and nc-cli services
- `.env.example`: Add `RAILS_API_URL` with example value

### Environment Variables

```bash
ANTHROPIC_API_KEY=your-key
RAILS_API_URL=https://api.ping-monitor-home.taylorcrib.com
NC_AGENT_NAME=noc-claude
NC_AGENT_SECRET=your-secret
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)