### PR TITLE
Configure docker-compose to use taylor01 registry

### DIFF
--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   ping-monitor:
     build: .
-    image: ping-monitor:latest
+    image: taylor01/ping-monitor:latest
     container_name: ping-monitor
     restart: unless-stopped
     environment:

--- a/noc_claude/docker-compose.yml
+++ b/noc_claude/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   nc:
     build: .
+    image: taylor01/noc-claude:latest
     container_name: noc-claude
     restart: unless-stopped
     
@@ -36,7 +37,7 @@ services:
 
   # CLI interface (run manually)
   nc-cli:
-    build: .
+    image: taylor01/noc-claude:latest
     container_name: noc-claude-cli
     profiles:
       - cli  # Only starts with: docker-compose --profile cli up nc-cli


### PR DESCRIPTION
## Summary

Configure both monitor and noc_claude docker-compose files to push images to the taylor01 Docker Hub registry.

### Changes

- **monitor**: `image: taylor01/ping-monitor:latest`
- **noc_claude**: `image: taylor01/noc-claude:latest`

### Usage

```bash
# Build and push
cd monitor && docker-compose build && docker-compose push
cd noc_claude && docker-compose build && docker-compose push

# Or pull on remote hosts
docker pull taylor01/ping-monitor:latest
docker pull taylor01/noc-claude:latest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)