### PR TITLE
Add JSON:API compliant includes for anomalies endpoint

### DIFF
--- a/api/app/controllers/api/v1/anomalies_controller.rb
+++ b/api/app/controllers/api/v1/anomalies_controller.rb
@@ -32,7 +32,11 @@ module Api
 
         anomalies = anomalies.limit(params[:limit] || 50)
 
-        render json: AnomalySerializer.new(anomalies, meta: anomaly_meta).serializable_hash
+        render json: AnomalySerializer.new(
+          anomalies,
+          include: parse_includes,
+          meta: anomaly_meta
+        ).serializable_hash
       end
 
       # GET /api/v1/anomalies/history
@@ -56,7 +60,7 @@ module Api
       # GET /api/v1/anomalies/:id
       def show
         anomaly = policy_scope(Anomaly).find(params[:id])
-        render json: AnomalySerializer.new(anomaly).serializable_hash
+        render json: AnomalySerializer.new(anomaly, include: parse_includes).serializable_hash
       rescue ActiveRecord::RecordNotFound
         render_jsonapi_error("Anomaly not found", status: :not_found)
       end
@@ -73,6 +77,17 @@ module Api
       end
 
       private
+
+      # Parse JSON:API include parameter
+      # Example: ?include=site,measurement -> [:site, :measurement]
+      ALLOWED_INCLUDES = %w[site measurement].freeze
+
+      def parse_includes
+        return [] unless params[:include].present?
+
+        requested = params[:include].split(",").map(&:strip)
+        requested.select { |inc| ALLOWED_INCLUDES.include?(inc) }.map(&:to_sym)
+      end
 
       def anomaly_meta
         # Single aggregated query to avoid N+1

--- a/api/spec/requests/api/v1/anomalies_spec.rb
+++ b/api/spec/requests/api/v1/anomalies_spec.rb
@@ -117,6 +117,43 @@ RSpec.describe "Api::V1::Anomalies", type: :request do
       expect(resolved_anomaly["attributes"]).to have_key("duration")
       expect(resolved_anomaly["attributes"]["duration"]).not_to be_nil
     end
+
+    context "with include parameter" do
+      it "includes site in response when requested" do
+        get "/api/v1/anomalies", params: { include: "site" }, headers: headers
+
+        json = json_response
+        expect(json["included"]).to be_an(Array)
+        expect(json["included"].first["type"]).to eq("sites")
+        expect(json["included"].first["attributes"]["name"]).to eq(site.name)
+      end
+
+      it "includes relationship data linking to included site" do
+        get "/api/v1/anomalies", params: { include: "site" }, headers: headers
+
+        json = json_response
+        anomaly_data = json["data"].first
+        expect(anomaly_data["relationships"]["site"]["data"]["type"]).to eq("sites")
+        expect(anomaly_data["relationships"]["site"]["data"]["id"]).to eq(site.id.to_s)
+      end
+
+      it "ignores invalid include values" do
+        get "/api/v1/anomalies", params: { include: "invalid,site" }, headers: headers
+
+        json = json_response
+        expect(json["included"]).to be_an(Array)
+        # Only site is included, invalid is ignored
+        included_types = json["included"].map { |i| i["type"] }
+        expect(included_types).to contain_exactly("sites")
+      end
+
+      it "returns no included when include param is empty" do
+        get "/api/v1/anomalies", headers: headers
+
+        json = json_response
+        expect(json["included"]).to be_nil
+      end
+    end
   end
 
   describe "GET /api/v1/anomalies/history" do
@@ -180,6 +217,15 @@ RSpec.describe "Api::V1::Anomalies", type: :request do
       get "/api/v1/anomalies/#{other_anomaly.id}", headers: headers
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    it "includes site when requested" do
+      get "/api/v1/anomalies/#{anomaly.id}", params: { include: "site" }, headers: headers
+
+      json = json_response
+      expect(json["included"]).to be_an(Array)
+      expect(json["included"].first["type"]).to eq("sites")
+      expect(json["included"].first["id"]).to eq(site.id.to_s)
     end
   end
 

--- a/noc_claude/nc/api_client.py
+++ b/noc_claude/nc/api_client.py
@@ -294,9 +294,34 @@ class RailsAPIClient:
         }
         return mapping.get(anomaly_type, anomaly_type)
 
-    def _parse_jsonapi_anomaly(self, item: Dict, site_name: str = '') -> Dict:
+    def _build_included_lookup(self, included: List[Dict]) -> Dict[str, Dict]:
+        """
+        Build a lookup dict from JSON:API included resources.
+
+        Returns:
+            Dict mapping "type:id" -> resource attributes
+        """
+        lookup = {}
+        for resource in included:
+            res_type = resource.get('type', '')
+            res_id = str(resource.get('id', ''))
+            key = f"{res_type}:{res_id}"
+            lookup[key] = resource.get('attributes', {})
+        return lookup
+
+    def _parse_jsonapi_anomaly(self, item: Dict, included_lookup: Dict[str, Dict]) -> Dict:
         """Parse a JSON:API anomaly item into NC alert format."""
         attrs = item.get('attributes', {})
+
+        # Get site name from included resources via relationship
+        site_name = ''
+        relationships = item.get('relationships', {})
+        site_rel = relationships.get('site', {}).get('data', {})
+        if site_rel:
+            site_key = f"{site_rel.get('type', 'sites')}:{site_rel.get('id', '')}"
+            site_attrs = included_lookup.get(site_key, {})
+            site_name = site_attrs.get('name', '')
+
         return {
             'id': item.get('id'),
             'site': site_name,
@@ -322,7 +347,9 @@ class RailsAPIClient:
         Returns:
             List of Alert objects
         """
-        params = {}
+        params = {
+            'include': 'site'  # JSON:API include for site data
+        }
 
         if status:
             params['status'] = status
@@ -335,10 +362,13 @@ class RailsAPIClient:
         # Call the Rails anomalies endpoint (JSON:API format)
         response = self._get("/api/v1/anomalies", params)
 
+        # Build lookup from included resources
+        included_lookup = self._build_included_lookup(response.get('included', []))
+
         # Parse JSON:API format
         alerts = []
         for item in response.get('data', []):
-            alert_data = self._parse_jsonapi_anomaly(item, site or '')
+            alert_data = self._parse_jsonapi_anomaly(item, included_lookup)
             alerts.append(Alert.from_api(alert_data))
 
         return alerts

--- a/noc_claude/tests/test_api_client.py
+++ b/noc_claude/tests/test_api_client.py
@@ -137,6 +137,165 @@ class TestTokenRefresh:
                 api_client.refresh_access_token()
 
 
+class TestJSONAPIParsing:
+    """Test JSON:API response parsing."""
+
+    def test_build_included_lookup(self, api_client):
+        """Builds lookup from included resources."""
+        included = [
+            {
+                "id": "1",
+                "type": "sites",
+                "attributes": {"name": "home", "status": "active"}
+            },
+            {
+                "id": "2",
+                "type": "sites",
+                "attributes": {"name": "cabin", "status": "active"}
+            }
+        ]
+
+        lookup = api_client._build_included_lookup(included)
+
+        assert lookup["sites:1"]["name"] == "home"
+        assert lookup["sites:2"]["name"] == "cabin"
+
+    def test_parse_jsonapi_anomaly_with_site(self, api_client):
+        """Parses anomaly with site from included lookup."""
+        included_lookup = {
+            "sites:1": {"name": "home", "status": "active"}
+        }
+
+        item = {
+            "id": "123",
+            "type": "anomalies",
+            "attributes": {
+                "host": "router",
+                "anomaly_type": "host_down",
+                "severity": "critical",
+                "message": "Host is down",
+                "created_at": "2024-01-15T10:30:00Z",
+                "resolved_at": None
+            },
+            "relationships": {
+                "site": {
+                    "data": {"id": "1", "type": "sites"}
+                }
+            }
+        }
+
+        result = api_client._parse_jsonapi_anomaly(item, included_lookup)
+
+        assert result["id"] == "123"
+        assert result["site"] == "home"
+        assert result["device"] == "router"
+        assert result["alert_type"] == "down"
+        assert result["severity"] == "critical"
+
+    def test_parse_jsonapi_anomaly_without_site_relationship(self, api_client):
+        """Handles anomaly without site relationship gracefully."""
+        included_lookup = {}
+
+        item = {
+            "id": "123",
+            "type": "anomalies",
+            "attributes": {
+                "host": "router",
+                "anomaly_type": "host_down",
+                "severity": "warning",
+                "message": "Host is down",
+                "created_at": "2024-01-15T10:30:00Z",
+                "resolved_at": None
+            },
+            "relationships": {}
+        }
+
+        result = api_client._parse_jsonapi_anomaly(item, included_lookup)
+
+        assert result["site"] == ""
+        assert result["device"] == "router"
+
+    def test_parse_jsonapi_anomaly_site_not_in_included(self, api_client):
+        """Handles missing site in included lookup."""
+        included_lookup = {}  # Empty lookup
+
+        item = {
+            "id": "123",
+            "type": "anomalies",
+            "attributes": {
+                "host": "router",
+                "anomaly_type": "host_down",
+                "severity": "warning",
+                "message": "Host is down",
+                "created_at": "2024-01-15T10:30:00Z",
+                "resolved_at": None
+            },
+            "relationships": {
+                "site": {
+                    "data": {"id": "999", "type": "sites"}
+                }
+            }
+        }
+
+        result = api_client._parse_jsonapi_anomaly(item, included_lookup)
+
+        assert result["site"] == ""
+
+    def test_get_alerts_requests_include_site(self, api_client):
+        """get_alerts requests site include."""
+        mock_auth_response = Mock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "data": {
+                "access_token": "test-token",
+                "refresh_token": "test-refresh",
+                "expires_in": 3600,
+                "scopes": []
+            }
+        }
+
+        mock_alerts_response = Mock()
+        mock_alerts_response.status_code = 200
+        mock_alerts_response.json.return_value = {
+            "data": [
+                {
+                    "id": "1",
+                    "type": "anomalies",
+                    "attributes": {
+                        "host": "router",
+                        "anomaly_type": "host_down",
+                        "severity": "critical",
+                        "message": "Down",
+                        "created_at": "2024-01-15T10:30:00Z",
+                        "resolved_at": None
+                    },
+                    "relationships": {
+                        "site": {"data": {"id": "1", "type": "sites"}}
+                    }
+                }
+            ],
+            "included": [
+                {
+                    "id": "1",
+                    "type": "sites",
+                    "attributes": {"name": "home"}
+                }
+            ]
+        }
+
+        with patch("requests.post", return_value=mock_auth_response):
+            with patch("requests.get", return_value=mock_alerts_response) as mock_get:
+                alerts = api_client.get_alerts()
+
+                # Verify include=site was passed
+                call_args = mock_get.call_args
+                assert call_args[1]["params"]["include"] == "site"
+
+                # Verify site name was parsed correctly
+                assert len(alerts) == 1
+                assert alerts[0].site == "home"
+
+
 class TestMockClient:
     """Test mock API client for development."""
 


### PR DESCRIPTION
## Summary

- Add JSON:API `?include=site` support to anomalies endpoint for proper resource inclusion
- Update NC to parse JSON:API `included` array to get site names from relationships
- Fixes issue where NC showed sites with empty names

## Changes

### API (Rails)
- `anomalies_controller.rb`: Add `parse_includes` helper supporting `?include=site,measurement`
- Pass includes to serializer for JSON:API compliant `included` array in response

### NC (Python)
- `api_client.py`: Add `_build_included_lookup()` to create type:id -> attributes lookup
- Update `_parse_jsonapi_anomaly()` to extract site name via relationship -> included lookup
- Request `?include=site` when fetching alerts

## Test plan

- [x] API tests: 25 passing (4 new tests for includes)
- [x] NC tests: 17 passing (5 new tests for JSON:API parsing)

## JSON:API Response Format

```json
{
  "data": [{
    "id": "1",
    "type": "anomalies",
    "relationships": {
      "site": { "data": { "id": "1", "type": "sites" } }
    }
  }],
  "included": [{
    "id": "1",
    "type": "sites",
    "attributes": { "name": "home" }
  }]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)