### PR TITLE
Fix NC alert reconciliation: sync local state with API

### DIFF
--- a/noc_claude/nc/main.py
+++ b/noc_claude/nc/main.py
@@ -79,25 +79,28 @@ class NOCClaude:
                         self._do_morning_summary()
                         last_summary_date = today
                 
-                # 2. Fetch new alerts from Rails API
-                new_alerts = self._fetch_new_alerts()
+                # 2. Fetch all active alerts from Rails API
+                alerts = self._fetch_alerts()
+
+                # 3. Ingest alerts and reconcile state
+                self.state.ingest_alerts(alerts, reconcile=True)
+                if alerts:
+                    self.output.info(f"Tracking {len(alerts)} active alerts")
+
+                # 4. Reconcile site states (reset sites with no active alerts)
+                self.state.reconcile_site_states()
                 
-                # 3. Ingest alerts into state
-                if new_alerts:
-                    self.state.ingest_alerts(new_alerts)
-                    self.output.info(f"Ingested {len(new_alerts)} new alerts")
-                
-                # 4. Check for state transitions (watching -> investigating)
+                # 5. Check for state transitions (watching -> investigating)
                 self._check_state_transitions()
-                
-                # 5. For each site needing attention, investigate
+
+                # 6. For each site needing attention, investigate
                 for site in self.state.sites_needing_attention():
                     self._investigate_site(site)
-                
-                # 6. Check for auto-recoveries
+
+                # 7. Check for auto-recoveries
                 self._check_recoveries()
-                
-                # 7. Sleep until next poll
+
+                # 8. Sleep until next poll
                 elapsed = time.time() - loop_start
                 sleep_time = max(0, self.config.poll_interval_seconds - elapsed)
                 time.sleep(sleep_time)
@@ -110,11 +113,11 @@ class NOCClaude:
                 
         self.output.system("NC shutdown complete.")
         
-    def _fetch_new_alerts(self) -> list:
-        """Fetch new alerts from Rails API."""
+    def _fetch_alerts(self) -> list:
+        """Fetch all active alerts from Rails API for full reconciliation."""
         try:
-            since = self.state.get_last_poll_time()
-            alerts = self.api.get_alerts(since=since)
+            # Fetch ALL active alerts (no 'since' filter) to properly reconcile state
+            alerts = self.api.get_alerts(status="active")
             self.state.update_last_poll_time()
             return alerts
         except Exception as e:

--- a/noc_claude/nc/state.py
+++ b/noc_claude/nc/state.py
@@ -249,9 +249,26 @@ class StateManager:
     # Alert Management
     # =========================================================================
     
-    def ingest_alerts(self, alerts: List[Alert]):
-        """Ingest new alerts from the API."""
+    def ingest_alerts(self, alerts: List[Alert], reconcile: bool = True):
+        """
+        Ingest alerts from the API.
+
+        Args:
+            alerts: List of alerts from the API
+            reconcile: If True, remove local alerts not in the API's active list.
+                      Set to True when fetching the full active alerts list.
+        """
         with self._get_conn() as conn:
+            # Get current active alert IDs from API response
+            api_alert_ids = {alert.id for alert in alerts if not alert.resolved_at}
+
+            # Reconcile: remove local alerts that are no longer active in API
+            if reconcile:
+                local_alerts = conn.execute("SELECT id FROM active_alerts").fetchall()
+                for row in local_alerts:
+                    if row['id'] not in api_alert_ids:
+                        conn.execute("DELETE FROM active_alerts WHERE id = ?", (row['id'],))
+
             for alert in alerts:
                 if alert.resolved_at:
                     # Alert resolved - remove from active
@@ -259,22 +276,22 @@ class StateManager:
                 else:
                     # New or ongoing alert
                     conn.execute("""
-                        INSERT OR REPLACE INTO active_alerts 
+                        INSERT OR REPLACE INTO active_alerts
                         (id, site, device, alert_type, severity, message, started_at)
                         VALUES (?, ?, ?, ?, ?, ?, ?)
                     """, (alert.id, alert.site, alert.device, alert.alert_type,
                           alert.severity, alert.message, alert.started_at.isoformat()))
-                    
+
                     # Ensure site has a state record
                     conn.execute("""
                         INSERT OR IGNORE INTO site_states (site, concern_level)
                         VALUES (?, 'NORMAL')
                     """, (alert.site,))
-                    
+
                     # If site is NORMAL, move to WATCHING
                     conn.execute("""
-                        UPDATE site_states 
-                        SET concern_level = 'WATCHING', 
+                        UPDATE site_states
+                        SET concern_level = 'WATCHING',
                             watching_since = COALESCE(watching_since, ?),
                             updated_at = CURRENT_TIMESTAMP
                         WHERE site = ? AND concern_level = 'NORMAL'
@@ -307,6 +324,22 @@ class StateManager:
         """Remove an alert from active alerts."""
         with self._get_conn() as conn:
             conn.execute("DELETE FROM active_alerts WHERE id = ?", (alert_id,))
+
+    def reconcile_site_states(self):
+        """
+        Reset concern levels for sites with no active alerts.
+        Should be called after ingesting alerts.
+        """
+        with self._get_conn() as conn:
+            # Get sites with elevated concern but no active alerts
+            conn.execute("""
+                UPDATE site_states
+                SET concern_level = 'NORMAL',
+                    watching_since = NULL,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE concern_level != 'NORMAL'
+                  AND site NOT IN (SELECT DISTINCT site FROM active_alerts)
+            """)
             
     # =========================================================================
     # Site State Management  

--- a/noc_claude/tests/test_state.py
+++ b/noc_claude/tests/test_state.py
@@ -1,0 +1,226 @@
+"""Tests for state management and alert reconciliation."""
+
+import pytest
+import tempfile
+import os
+from datetime import datetime, timezone
+
+from nc.state import StateManager, Alert
+
+
+@pytest.fixture
+def state_manager():
+    """Create a StateManager with a temporary database."""
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    manager = StateManager(db_path)
+    yield manager
+    # Cleanup
+    os.unlink(db_path)
+
+
+def make_alert(id: str, site: str = "home", device: str = "router",
+               alert_type: str = "down", resolved: bool = False) -> Alert:
+    """Helper to create test alerts."""
+    return Alert(
+        id=id,
+        site=site,
+        device=device,
+        alert_type=alert_type,
+        severity="warning",
+        message=f"{device} is {alert_type}",
+        started_at=datetime.now(timezone.utc),
+        resolved_at=datetime.now(timezone.utc) if resolved else None
+    )
+
+
+class TestAlertIngestion:
+    """Test alert ingestion and caching."""
+
+    def test_ingest_new_alert(self, state_manager):
+        """New alerts are cached in active_alerts."""
+        alerts = [make_alert("1", site="home", device="router")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        active = state_manager.get_active_alerts()
+        assert len(active) == 1
+        assert active[0].id == "1"
+        assert active[0].device == "router"
+
+    def test_ingest_resolved_alert_removes_from_cache(self, state_manager):
+        """Resolved alerts are removed from active_alerts."""
+        # First ingest an active alert
+        alerts = [make_alert("1")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+        assert len(state_manager.get_active_alerts()) == 1
+
+        # Now ingest same alert as resolved
+        alerts = [make_alert("1", resolved=True)]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+        assert len(state_manager.get_active_alerts()) == 0
+
+    def test_ingest_multiple_alerts(self, state_manager):
+        """Multiple alerts from different sites are cached."""
+        alerts = [
+            make_alert("1", site="home", device="router"),
+            make_alert("2", site="home", device="switch"),
+            make_alert("3", site="cabin", device="ap"),
+        ]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        active = state_manager.get_active_alerts()
+        assert len(active) == 3
+
+        home_alerts = state_manager.get_active_alerts(site="home")
+        assert len(home_alerts) == 2
+
+        cabin_alerts = state_manager.get_active_alerts(site="cabin")
+        assert len(cabin_alerts) == 1
+
+
+class TestAlertReconciliation:
+    """Test reconciliation of local state with API state."""
+
+    def test_reconcile_removes_stale_alerts(self, state_manager):
+        """Alerts not in API response are removed when reconcile=True."""
+        # Ingest 3 alerts
+        initial_alerts = [
+            make_alert("1", device="router"),
+            make_alert("2", device="switch"),
+            make_alert("3", device="ap"),
+        ]
+        state_manager.ingest_alerts(initial_alerts, reconcile=False)
+        assert len(state_manager.get_active_alerts()) == 3
+
+        # API now only returns 1 active alert (2 and 3 resolved externally)
+        current_alerts = [make_alert("1", device="router")]
+        state_manager.ingest_alerts(current_alerts, reconcile=True)
+
+        # Only alert 1 should remain
+        active = state_manager.get_active_alerts()
+        assert len(active) == 1
+        assert active[0].id == "1"
+
+    def test_reconcile_removes_all_alerts_when_empty(self, state_manager):
+        """All alerts removed when API returns empty list."""
+        # Ingest some alerts
+        alerts = [make_alert("1"), make_alert("2")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+        assert len(state_manager.get_active_alerts()) == 2
+
+        # API returns empty list - all resolved
+        state_manager.ingest_alerts([], reconcile=True)
+        assert len(state_manager.get_active_alerts()) == 0
+
+    def test_reconcile_false_preserves_stale_alerts(self, state_manager):
+        """Stale alerts preserved when reconcile=False."""
+        # Ingest 2 alerts
+        alerts = [make_alert("1"), make_alert("2")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        # Ingest only 1 alert without reconciliation
+        alerts = [make_alert("1")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        # Both alerts should still exist
+        assert len(state_manager.get_active_alerts()) == 2
+
+    def test_reconcile_adds_new_and_removes_stale(self, state_manager):
+        """Reconciliation handles add and remove simultaneously."""
+        # Start with alerts 1 and 2
+        alerts = [make_alert("1"), make_alert("2")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        # API now has alerts 2 and 3 (1 resolved, 3 new)
+        alerts = [make_alert("2"), make_alert("3")]
+        state_manager.ingest_alerts(alerts, reconcile=True)
+
+        active = state_manager.get_active_alerts()
+        assert len(active) == 2
+        ids = {a.id for a in active}
+        assert ids == {"2", "3"}
+
+
+class TestSiteStateReconciliation:
+    """Test site concern level reconciliation."""
+
+    def test_site_moves_to_watching_on_alert(self, state_manager):
+        """Site concern level changes to WATCHING when alert ingested."""
+        alerts = [make_alert("1", site="home")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        statuses = state_manager.get_all_site_statuses()
+        assert statuses.get("home") == "WATCHING"
+
+    def test_reconcile_resets_sites_with_no_alerts(self, state_manager):
+        """Sites with no active alerts are reset to NORMAL."""
+        # Create alert and escalate site
+        alerts = [make_alert("1", site="home")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+        state_manager.set_concern_level("home", "ESCALATED")
+
+        # Verify escalated
+        assert state_manager.get_all_site_statuses()["home"] == "ESCALATED"
+
+        # All alerts resolved
+        state_manager.ingest_alerts([], reconcile=True)
+        state_manager.reconcile_site_states()
+
+        # Site should be NORMAL now
+        statuses = state_manager.get_all_site_statuses()
+        assert statuses.get("home") == "NORMAL"
+
+    def test_reconcile_preserves_sites_with_alerts(self, state_manager):
+        """Sites with active alerts keep their concern level."""
+        # Create alerts for two sites
+        alerts = [
+            make_alert("1", site="home"),
+            make_alert("2", site="cabin"),
+        ]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+        state_manager.set_concern_level("home", "INVESTIGATING")
+        state_manager.set_concern_level("cabin", "ESCALATED")
+
+        # Remove cabin alert but keep home alert
+        alerts = [make_alert("1", site="home")]
+        state_manager.ingest_alerts(alerts, reconcile=True)
+        state_manager.reconcile_site_states()
+
+        statuses = state_manager.get_all_site_statuses()
+        # Home still has alerts - keep level
+        assert statuses["home"] == "INVESTIGATING"
+        # Cabin has no alerts - reset to NORMAL
+        assert statuses["cabin"] == "NORMAL"
+
+    def test_reconcile_resets_watching_since(self, state_manager):
+        """watching_since is cleared when site returns to NORMAL."""
+        # Create alert
+        alerts = [make_alert("1", site="home")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        # Verify watching_since is set
+        context = state_manager.get_site_context("home")
+        assert context.watching_since is not None
+
+        # Remove all alerts and reconcile
+        state_manager.ingest_alerts([], reconcile=True)
+        state_manager.reconcile_site_states()
+
+        # watching_since should be None
+        context = state_manager.get_site_context("home")
+        assert context.watching_since is None
+
+
+class TestClearAlert:
+    """Test individual alert clearing."""
+
+    def test_clear_alert_removes_single(self, state_manager):
+        """clear_alert removes just the specified alert."""
+        alerts = [make_alert("1"), make_alert("2")]
+        state_manager.ingest_alerts(alerts, reconcile=False)
+
+        state_manager.clear_alert("1")
+
+        active = state_manager.get_active_alerts()
+        assert len(active) == 1
+        assert active[0].id == "2"


### PR DESCRIPTION
## Summary

- Fix stale alerts persisting in NC's local cache indefinitely
- NC now fetches ALL active alerts each poll (not just new since last poll)
- Local alerts not present in API response are removed
- Site concern levels reset to NORMAL when no active alerts remain

## Problem

NC was only fetching alerts created since the last poll time. When alerts were resolved in the API, NC never saw the resolution (since resolved alerts aren't "new") and kept them cached forever. This caused NC to show 209 active alerts while the API had 0.

## Solution

Changed reconciliation strategy:
1. `_fetch_alerts()` now fetches all active alerts (no `since` filter)
2. `ingest_alerts(reconcile=True)` removes local alerts missing from API response
3. `reconcile_site_states()` resets sites with no active alerts to NORMAL

## Test plan

- [x] Added 12 unit tests for reconciliation logic
- [x] All 29 tests pass
- [ ] Deploy to staging and verify NC clears stale alerts
- [ ] Verify NC properly tracks new alerts after reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)