### PR TITLE
Add host_ip to alerts for direct IP pinging

### DIFF
--- a/noc_claude/nc/api_client.py
+++ b/noc_claude/nc/api_client.py
@@ -312,15 +312,23 @@ class RailsAPIClient:
     def _parse_jsonapi_anomaly(self, item: Dict, included_lookup: Dict[str, Dict]) -> Dict:
         """Parse a JSON:API anomaly item into NC alert format."""
         attrs = item.get('attributes', {})
+        relationships = item.get('relationships', {})
 
         # Get site name from included resources via relationship
         site_name = ''
-        relationships = item.get('relationships', {})
         site_rel = relationships.get('site', {}).get('data', {})
         if site_rel:
             site_key = f"{site_rel.get('type', 'sites')}:{site_rel.get('id', '')}"
             site_attrs = included_lookup.get(site_key, {})
             site_name = site_attrs.get('name', '')
+
+        # Get host IP from included measurement via relationship
+        host_ip = ''
+        measurement_rel = relationships.get('measurement', {}).get('data', {})
+        if measurement_rel:
+            measurement_key = f"{measurement_rel.get('type', 'measurements')}:{measurement_rel.get('id', '')}"
+            measurement_attrs = included_lookup.get(measurement_key, {})
+            host_ip = measurement_attrs.get('ip', '')
 
         # For site-level anomalies (site_offline), host may be null
         device = attrs.get('host') or '[site]'
@@ -329,6 +337,7 @@ class RailsAPIClient:
             'id': item.get('id'),
             'site': site_name,
             'device': device,
+            'host_ip': host_ip,
             'alert_type': self._map_anomaly_type(attrs.get('anomaly_type', 'unknown')),
             'severity': attrs.get('severity', 'warning'),
             'message': attrs.get('message', ''),
@@ -351,7 +360,7 @@ class RailsAPIClient:
             List of Alert objects
         """
         params = {
-            'include': 'site'  # JSON:API include for site data
+            'include': 'site,measurement'  # JSON:API include for site and measurement data
         }
 
         if status:

--- a/noc_claude/nc/claude_client.py
+++ b/noc_claude/nc/claude_client.py
@@ -85,20 +85,24 @@ DEVICES: switch-main.home, ap-garage.home, ap-living.home
 NC_TOOLS = [
     {
         "name": "ping_device",
-        "description": "ICMP ping a device to check if it's reachable from NC's location. Use this to verify if a device is actually down or if it's a monitoring issue.",
+        "description": "ICMP ping a device to check if it's reachable from NC's location. Use this to verify if a device is actually down or if it's a monitoring issue. Always prefer using host_ip over host to avoid DNS resolution issues.",
         "input_schema": {
             "type": "object",
             "properties": {
                 "host": {
                     "type": "string",
-                    "description": "IP address or hostname to ping"
+                    "description": "Device hostname/name (for display purposes)"
+                },
+                "host_ip": {
+                    "type": "string",
+                    "description": "IP address to ping (preferred over hostname)"
                 },
                 "site": {
                     "type": "string",
                     "description": "Site name (for Tailscale routing if needed)"
                 }
             },
-            "required": ["host"]
+            "required": []
         }
     },
     {

--- a/noc_claude/nc/state.py
+++ b/noc_claude/nc/state.py
@@ -23,7 +23,8 @@ class Alert:
     message: str
     started_at: datetime
     resolved_at: Optional[datetime] = None
-    
+    host_ip: Optional[str] = None  # IP address for direct pinging
+
     @classmethod
     def from_api(cls, data: dict) -> "Alert":
         """Create Alert from API response."""
@@ -35,7 +36,8 @@ class Alert:
             severity=data.get('severity', 'warning'),
             message=data.get('message', ''),
             started_at=datetime.fromisoformat(data['started_at'].replace('Z', '+00:00')) if data.get('started_at') else datetime.now(timezone.utc),
-            resolved_at=datetime.fromisoformat(data['resolved_at'].replace('Z', '+00:00')) if data.get('resolved_at') else None
+            resolved_at=datetime.fromisoformat(data['resolved_at'].replace('Z', '+00:00')) if data.get('resolved_at') else None,
+            host_ip=data.get('host_ip') or None
         )
 
 
@@ -231,6 +233,7 @@ class StateManager:
                     id TEXT PRIMARY KEY,
                     site TEXT NOT NULL,
                     device TEXT NOT NULL,
+                    host_ip TEXT,
                     alert_type TEXT NOT NULL,
                     severity TEXT,
                     message TEXT,
@@ -277,10 +280,11 @@ class StateManager:
                     # New or ongoing alert
                     conn.execute("""
                         INSERT OR REPLACE INTO active_alerts
-                        (id, site, device, alert_type, severity, message, started_at)
-                        VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """, (alert.id, alert.site, alert.device, alert.alert_type,
-                          alert.severity, alert.message, alert.started_at.isoformat()))
+                        (id, site, device, host_ip, alert_type, severity, message, started_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """, (alert.id, alert.site, alert.device, alert.host_ip,
+                          alert.alert_type, alert.severity, alert.message,
+                          alert.started_at.isoformat()))
 
                     # Ensure site has a state record
                     conn.execute("""
@@ -317,7 +321,8 @@ class StateManager:
             alert_type=row['alert_type'],
             severity=row['severity'],
             message=row['message'],
-            started_at=datetime.fromisoformat(row['started_at'])
+            started_at=datetime.fromisoformat(row['started_at']),
+            host_ip=row['host_ip']
         ) for row in rows]
         
     def clear_alert(self, alert_id: str):

--- a/noc_claude/nc/tools.py
+++ b/noc_claude/nc/tools.py
@@ -55,37 +55,40 @@ class ToolExecutor:
     def _ping_device(self, params: Dict[str, Any]) -> str:
         """Ping a device and return results."""
         host = params.get("host")
+        host_ip = params.get("host_ip")
         site = params.get("site")
-        
-        if not host:
-            return "Error: host parameter required"
-            
-        # If site is specified and we have a Tailscale IP, we might need to route through it
-        # For now, direct ping
+
+        if not host and not host_ip:
+            return "Error: host or host_ip parameter required"
+
+        # Prefer IP address over hostname to avoid DNS resolution issues
+        ping_target = host_ip if host_ip else host
+        display_name = f"{host} ({host_ip})" if host_ip and host else (host or host_ip)
+
         try:
             result = subprocess.run(
-                ["ping", "-c", "3", "-W", "2", host],
+                ["ping", "-c", "3", "-W", "2", ping_target],
                 capture_output=True,
                 text=True,
                 timeout=10
             )
-            
+
             if result.returncode == 0:
                 # Parse latency from output
                 lines = result.stdout.strip().split('\n')
                 stats_line = [l for l in lines if 'avg' in l.lower() or 'rtt' in l.lower()]
                 if stats_line:
-                    return f"REACHABLE: {host} is responding. {stats_line[-1]}"
-                return f"REACHABLE: {host} is responding."
+                    return f"REACHABLE: {display_name} is responding. {stats_line[-1]}"
+                return f"REACHABLE: {display_name} is responding."
             else:
-                return f"UNREACHABLE: {host} is not responding to ping."
-                
+                return f"UNREACHABLE: {display_name} is not responding to ping."
+
         except subprocess.TimeoutExpired:
-            return f"TIMEOUT: {host} ping timed out after 10 seconds."
+            return f"TIMEOUT: {display_name} ping timed out after 10 seconds."
         except FileNotFoundError:
             return f"ERROR: ping command not available."
         except Exception as e:
-            return f"ERROR: Failed to ping {host}: {str(e)}"
+            return f"ERROR: Failed to ping {display_name}: {str(e)}"
             
     def _check_tailscale_status(self, params: Dict[str, Any]) -> str:
         """Check Tailscale status for a site."""

--- a/noc_claude/tests/test_api_client.py
+++ b/noc_claude/tests/test_api_client.py
@@ -287,9 +287,9 @@ class TestJSONAPIParsing:
             with patch("requests.get", return_value=mock_alerts_response) as mock_get:
                 alerts = api_client.get_alerts()
 
-                # Verify include=site was passed
+                # Verify include=site,measurement was passed
                 call_args = mock_get.call_args
-                assert call_args[1]["params"]["include"] == "site"
+                assert call_args[1]["params"]["include"] == "site,measurement"
 
                 # Verify site name was parsed correctly
                 assert len(alerts) == 1


### PR DESCRIPTION
## Summary

- NC now fetches measurement data via JSON:API `include=site,measurement`
- Extracts `host_ip` from the included measurement resource
- `ping_device` tool prefers IP address over hostname to avoid DNS resolution issues

## Problem

When NC called `ping_device(host=Sonos-5)`, it was trying to resolve the hostname which doesn't exist in NC's Docker container DNS. This caused false negatives during troubleshooting.

## Solution

Use the standard JSON:API include mechanism to fetch the measurement's IP address. No schema changes needed on the API side - the serializers already support it.

**NC changes:**
- `api_client.py`: Request `include=site,measurement`, extract `host_ip`
- `state.py`: Add `host_ip` field to Alert and active_alerts table
- `tools.py`: Prefer `host_ip` over hostname when pinging
- `claude_client.py`: Update tool definition

## Test plan

- [x] All 29 NC tests pass
- [ ] Deploy and verify NC pings by IP address
- [ ] Verify ping output shows both name and IP: `REACHABLE: Sonos-5 (192.168.1.65)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)